### PR TITLE
Add support for loading next image on GDEMU

### DIFF
--- a/patcher/Makefile
+++ b/patcher/Makefile
@@ -22,6 +22,11 @@ OBJCOPY = sh-elf-objcopy -O binary
 OBJS = startup.o cdrom.o gd.o patch.o cdfs.o patcher.o video.o biosfont.o \
 	   fb_console.o maple.o utils.o cache.o
 
+ifdef GDEMU
+OBJS += gdemu.o
+CC += -DGDEMU
+endif
+
 all: rm-elf patcher.bin
 
 prpatcher: CC += -DPLANET_RING
@@ -46,6 +51,6 @@ rm-elf:
 
 .PHONY : clean
 clean:
-	-rm -f $(OBJS)
+	-rm -f $(OBJS) gdemu.o
 	-rm -f *.elf
 	-rm -f *.bin

--- a/patcher/gdemu.c
+++ b/patcher/gdemu.c
@@ -1,0 +1,85 @@
+/* GDEMU SDK
+
+   Copyright (C) 2019 megavolt85
+
+   KallistiOS ##version##
+   hardware/g1ata.c
+
+   Copyright (C) 2013, 2014, 2015 Lawrence Sebald
+*/
+
+#include "gdemu.h"
+#include "utils.h"
+
+#define ATAPI_CMD_PACKET        0xA0
+
+/* ATA-related registers. Some of these serve very different purposes when read
+   than they do when written (hence why some addresses are duplicated). */
+#define G1_ATA_ALTSTATUS        0xA05F7018      /* Read */
+#define G1_ATA_DATA             0xA05F7080      /* Read/Write */
+#define G1_ATA_STATUS_REG       0xA05F709C      /* Read */
+#define G1_ATA_COMMAND_REG      0xA05F709C      /* Write */
+
+/* status of the external interrupts
+ * bit 3 = External Device interrupt
+ * bit 2 = Modem interrupt
+ * bit 1 = AICA interrupt
+ * bit 0 = GD-ROM interrupt */
+#define EXT_INT_STAT            0xA05F6904      /* Read */
+
+/* Bitmasks for the STATUS_REG/ALT_STATUS registers. */
+#define G1_ATA_SR_ERR   0x01
+#define G1_ATA_SR_DRQ   0x08
+#define G1_ATA_SR_BSY   0x80
+
+/* Macros to access the ATA registers */
+#define OUT16(addr, data) *((volatile uint16 *)addr) = data
+#define OUT8(addr, data)  *((volatile uint8  *)addr) = data
+#define IN32(addr)        *((volatile uint32 *)addr)
+#define IN8(addr)         *((volatile uint8  *)addr)
+
+#define g1_ata_wait_interrupt() \
+    do {} while(!(IN32(EXT_INT_STAT) & 1));
+
+#define g1_ata_wait_status(n) \
+    do {} while((IN8(G1_ATA_ALTSTATUS) & (n)))
+
+#define g1_ata_wait_nstatus(n) \
+    do {} while(!(IN8(G1_ATA_ALTSTATUS) & (n)))
+
+#define g1_ata_wait_drq() g1_ata_wait_nstatus(G1_ATA_SR_DRQ)
+
+#define g1_ata_wait_bsydrq() g1_ata_wait_status(G1_ATA_SR_DRQ | G1_ATA_SR_BSY)
+
+static int send_packet_command(uint16 *cmd_buff)
+{
+    g1_ata_wait_bsydrq();
+    OUT8(G1_ATA_COMMAND_REG, ATAPI_CMD_PACKET);
+    g1_ata_wait_drq();
+
+    (void) IN32(G1_ATA_STATUS_REG);
+    int i;
+    for (i = 0; i < 6; i++) {
+        OUT16(G1_ATA_DATA, cmd_buff[i]);
+    }
+
+    g1_ata_wait_interrupt();
+
+    (void) IN32(G1_ATA_STATUS_REG);
+
+    return (IN8(G1_ATA_ALTSTATUS) & G1_ATA_SR_ERR);
+}
+
+/* param = 0x55 next img */
+/* param = 0x44 prev img */
+int gdemu_img_cmd(uint8 cmd)
+{
+    uint8 cmd_buff[12];
+    memset(cmd_buff, 0, 12);
+
+    cmd_buff[0] = 0x52;
+    cmd_buff[1] = 0x81;
+    cmd_buff[2] = cmd;
+
+    return send_packet_command((uint16 *) cmd_buff);
+}

--- a/patcher/gdemu.h
+++ b/patcher/gdemu.h
@@ -1,0 +1,11 @@
+#ifndef GDEMU_H
+#define GDEMU_H
+
+#include "types.h"
+
+#define GDEMU_IMG_NEXT 0x55
+#define GDEMU_IMG_PREV 0x44
+
+int gdemu_img_cmd(uint8 cmd);
+
+#endif /* GDEMU_H */

--- a/patcher/patcher.c
+++ b/patcher/patcher.c
@@ -29,6 +29,10 @@
 #include "prbg.h"
 #endif
 
+#ifdef GDEMU
+#include "gdemu.h"
+#endif
+
 #define BIN_BASE    0xac010000
 #define IP_BASE     0xac008000
 #define SYS_BASE    0x8c008000
@@ -246,8 +250,14 @@ restart:
                     "Copyright (C) 2011-2013 Lawrence Sebald\n\n");
 #endif
 
+#ifndef GDEMU
     /* Wait for the user to insert a GD-ROM */
     fb_write_string("Please insert a GD-ROM...\n");
+#else
+    /* Automatically load the next image on GDEMU */
+    fb_write_string("Loading next image from GDEMU...\n");
+    gdemu_img_cmd(GDEMU_IMG_NEXT);
+#endif
     wait_for_disc();
 
     fb_write_string("Please wait while the disc is read...\n");
@@ -345,7 +355,7 @@ restart:
         patches_enabled = 0;
     }
     else {
-        /* Copy the GD-ROM syscall replacement... We can use from 0x8C008000 - 
+        /* Copy the GD-ROM syscall replacement... We can use from 0x8C008000 -
            0x8C0082FF (768 bytes) without making PSO angry.
            Not a lot of space, but it should be enough. */
         /* First fill in all the variables that it needs... */
@@ -395,7 +405,7 @@ restart:
         /* Copy the map table stuff, as appropriate. */
         memcpy((void *)MAP_TABLE, map_ptrs[disc->index], sizeof(uint32) * 48);
         memcpy((void *)MAP_NAMES, map_names, 68);
-#endif        
+#endif
 
         dcache_flush_range(SYS_BASE, 768);
     }


### PR DESCRIPTION
This PR adds support for automatically loading the next image on GDEMU without requiring a physical button press. This is not configurable so a separate GDEMU build should be created.

Usage:
1. Place CDI on GDEMU SD card (e.g. `02/loader-gdemu.cdi`)
2. Place your PSO copy as next image on the SD card (e.g. `03/pso.gdi`)
3. Start up GDEMU and load PSO Patcher

I've stripped the GDEMU SDK down to it's bare essentials and tried to give appropriate credits in `gdemu.c`, some definitions came from KallistiOS and megavolt85 provided the GDEMU SDK.

This can be built via `make GDEMU=1` for both PSO and Planet Ring, although I haven't tested it on Planet Ring yet.

Here's a working CDI build if anyone wants to try it out: [pso_patcher-2.0-gdemu-cdi.zip](https://github.com/Sylverant/pso_patcher/files/3537123/pso_patcher-2.0-gdemu-cdi.zip)

PS. I was planning on adding cycling functionality (back/forward + re-read disk) but I wanted to keep the changes non-intrusive and minimal, I believe a larger rewrite would be necessary to support this.